### PR TITLE
Fix error during close

### DIFF
--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -209,7 +209,8 @@ class Channel:
         return Stream(self, request, request_type, reply_type)
 
     def close(self):
-        self._protocol.processor.close()
+        if self._protocol is not None:
+            self._protocol.processor.close()
 
 
 class ServiceMethod:


### PR DESCRIPTION
`_protocol` attribute of Channel class is initialized when `__connect__`  is called.

If connect was never called `_protocol` is None and `close` method will fail with following error

```
channel.close()
File "/usr/local/lib/python3.6/dist-packages/grpclib/client.py", line 212, in close
  self._protocol.processor.close()
AttributeError: 'NoneType' object has no attribute 'processor'
```
