### PR TITLE
Feature suggestion: Allow replacable codecs

### DIFF
--- a/example/customcodec/client.py
+++ b/example/customcodec/client.py
@@ -1,0 +1,36 @@
+import asyncio
+from grpclib.client import Channel
+import grpclib
+from .codec import JSONCodec
+
+
+class GreeterStub:
+
+    def __init__(self, channel):
+        self.UnaryUnaryGreeting = grpclib.client.UnaryUnaryMethod(
+            channel,
+            '/HelloWorld/UnaryUnaryGreeting',
+            None,
+            None
+        )
+
+
+async def main():    
+    channel = Channel(loop=asyncio.get_event_loop(), codec=JSONCodec)
+    stub = GreeterStub(channel)
+    
+    print('Demonstrating UNARY_UNARY')
+
+    # Demonstrate simple case where requests are known before interaction
+    print(await stub.UnaryUnaryGreeting({'name': 'you'}))
+
+    # This block performs the same UNARY_UNARY interaction as above
+    # while showing more advanced stream control features.
+    async with stub.UnaryUnaryGreeting.open() as stream:
+        await stream.send_message({'name': 'you'})
+        reply = await stream.recv_message()
+        print(reply)
+
+
+if __name__ == '__main__':
+    asyncio.get_event_loop().run_until_complete(main())

--- a/example/customcodec/codec.py
+++ b/example/customcodec/codec.py
@@ -1,0 +1,27 @@
+import json
+import struct
+
+
+class JSONCodec:
+
+    CONTENT_TYPE = 'application/grpc+json'
+    CONTENT_TYPES = {'application/grpc', 'application/grpc+json'}
+
+    @staticmethod
+    async def recv_message(stream, message_type):
+        header = await stream.recv_data(4)
+        if not header:
+            return
+
+        message_len = struct.unpack('I', header)[0]
+        message_bin = await stream.recv_data(message_len)
+        
+        return json.loads(message_bin)
+
+    @staticmethod
+    async def send_message(stream, message, message_type, *, end=False):
+        message_bin = json.dumps(message).encode('utf-8')
+
+        await stream.send_data(
+            struct.pack('I', len(message_bin)) + message_bin, 
+            end_stream=end)

--- a/example/customcodec/server.py
+++ b/example/customcodec/server.py
@@ -1,0 +1,42 @@
+import asyncio
+from grpclib.server import Server
+import grpclib
+from .codec import JSONCodec
+
+
+class Greeter:
+
+    async def unary_unary_greeting(self, stream):
+        msg = await stream.recv_message()
+        await stream.send_message({'greeting': 'hello, %s' % msg['name']})
+
+    def __mapping__(self):
+        return {
+            '/HelloWorld/UnaryUnaryGreeting': grpclib.const.Handler(
+                self.unary_unary_greeting,
+                grpclib.const.Cardinality.UNARY_UNARY,
+                None,
+                None
+            )
+        }
+
+
+def main():
+    loop = asyncio.get_event_loop()
+
+    server = Server([Greeter()], loop=loop, codec=JSONCodec)
+    host, port = '127.0.0.1', 50051
+    loop.run_until_complete(server.start(host, port))
+
+    print('Serving on {}:{}'.format(host, port))
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+    server.close()
+    loop.run_until_complete(server.wait_closed())
+    loop.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/grpclib/stream.py
+++ b/grpclib/stream.py
@@ -2,34 +2,36 @@ import abc
 import struct
 
 
-CONTENT_TYPE = 'application/grpc+proto'
-CONTENT_TYPES = {'application/grpc', 'application/grpc+proto'}
+class ProtocolBuffersCodec:
 
+    CONTENT_TYPE = 'application/grpc+proto'
+    CONTENT_TYPES = {'application/grpc', 'application/grpc+proto'}
 
-async def recv_message(stream, message_type):
-    meta = await stream.recv_data(5)
-    if not meta:
-        return
+    @staticmethod
+    async def recv_message(stream, message_type):
+        meta = await stream.recv_data(5)
+        if not meta:
+            return
 
-    compressed_flag = struct.unpack('?', meta[:1])[0]
-    if compressed_flag:
-        raise NotImplementedError('Compression not implemented')
+        compressed_flag = struct.unpack('?', meta[:1])[0]
+        if compressed_flag:
+            raise NotImplementedError('Compression not implemented')
 
-    message_len = struct.unpack('>I', meta[1:])[0]
-    message_bin = await stream.recv_data(message_len)
-    assert len(message_bin) == message_len, \
-        '{} != {}'.format(len(message_bin), message_len)
-    message = message_type.FromString(message_bin)
-    return message
+        message_len = struct.unpack('>I', meta[1:])[0]
+        message_bin = await stream.recv_data(message_len)
+        assert len(message_bin) == message_len, \
+            '{} != {}'.format(len(message_bin), message_len)
+        message = message_type.FromString(message_bin)
+        return message
 
-
-async def send_message(stream, message, message_type, *, end=False):
-    assert isinstance(message, message_type), type(message)
-    reply_bin = message.SerializeToString()
-    reply_data = (struct.pack('?', False)
-                  + struct.pack('>I', len(reply_bin))
-                  + reply_bin)
-    await stream.send_data(reply_data, end_stream=end)
+    @staticmethod
+    async def send_message(stream, message, message_type, *, end=False):
+        assert isinstance(message, message_type), type(message)
+        reply_bin = message.SerializeToString()
+        reply_data = (struct.pack('?', False)
+                      + struct.pack('>I', len(reply_bin))
+                      + reply_bin)
+        await stream.send_data(reply_data, end_stream=end)
 
 
 class StreamIterator(abc.ABC):


### PR DESCRIPTION
I love working with gRPC, but sometimes prefer to work without Protocol Buffers as an IDN, in particular since the generated code is so unpythonic.

The idea that grpc could be used with a wire format other than Protocol Buffers is not new, see for example https://github.com/grpc/grpc-go/issues/803, https://groups.google.com/forum/#!topic/grpc-io/RLPH9D67sSc, or https://github.com/getlantern/getlantern.github.io/blob/master/_posts/2016-08-02-grpc-without-protocol-buffers.markdown. It seems to be part of the spec (https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) and most prominently supported by the golang implementation.

I tried to add something similar to grpclib. This would allow someone to use the programming interface of grpclib and the multiplexing ability of gRPC, but plug in a different message format, for example MessagePack.

As you can see, it was possible to do this without too many changes; grpclib already has a well thought out structure, and the two things I did were:

- Move the encoding/decoding helpers in stream.py into a class.
- Allow a codec class to be passed through the code.

An example for client/server is included, but no tests yet.

This is a working proof of concept, but I am open to working on it more if it's something you can see in grpclib.