### PR TITLE
On the client side, handle a server shutdown.

### DIFF
--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -276,6 +276,7 @@ class Stream(StreamIterator):
                 self._recv_trailing_metadata_done
                 or self._cancel_done
                 or not self._send_request_done
+                or self._stream._connection._transport.is_closing()
             ):
                 return
 

--- a/grpclib/protocol.py
+++ b/grpclib/protocol.py
@@ -353,6 +353,8 @@ class EventsProcessor:
     def close(self):
         self.connection.close()
         self.handler.close()
+        for stream in self.streams.values():
+            stream.__ended__()
 
     def process(self, event):
         try:


### PR DESCRIPTION
I have a client that is reading a stream from the server. When the server shuts down, the client hangs, basically because it is waiting here:

```
  File ".../grpclib/grpclib/protocol.py", line 93, in read
    await self._ready_event.wait()
```

Making sure that when we get ``connection_lost`` from the asyncio protocol that all the streams are closed fixes it for  me (this will set the ready_event in the buffer).

In addition, I had to make sure that the ``async with api.Method.open() as stream:`` context manager doesn't hang in `__aexit__` after that trying to read the trailing metadata.

What else is needed?