### PR TITLE
Use absolute import paths in plugin main

### DIFF
--- a/grpclib/plugin/main.py
+++ b/grpclib/plugin/main.py
@@ -184,3 +184,7 @@ def main():
 
     with os.fdopen(sys.stdout.fileno(), 'wb') as out:
         out.write(response.SerializeToString())
+
+
+if __name__ == '__main__':
+    main()

--- a/grpclib/plugin/main.py
+++ b/grpclib/plugin/main.py
@@ -7,8 +7,8 @@ from collections import namedtuple
 from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest
 from google.protobuf.compiler.plugin_pb2 import CodeGeneratorResponse
 
-from .. import const
-from .. import client
+from grpclib import const
+from grpclib import client
 
 
 SUFFIX = '_grpc.py'

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,11 @@
-import re
 import os.path
 
 from setuptools import setup, find_packages
 
+import grpclib
 
-with open(
-    os.path.join(os.path.dirname(__file__), 'grpclib', '__init__.py')
-) as f:
-    VERSION = re.match(r".*__version__ = '(.*?)'", f.read(), re.S).group(1)
+
+VERSION = grpclib.__version__
 
 with open(
     os.path.join(os.path.dirname(__file__), 'README.rst')


### PR DESCRIPTION
This change sets the import paths to be absolute in `plugin/main.py`, due to the following requirement from https://docs.python.org/3/tutorial/modules.html#intra-package-references
> Note that relative imports are based on the name of the current module. Since the name of the main module is always "__main__", modules intended for use as the main module of a Python application must always use absolute imports.

The present solution works when called via the `console_scripts` in setup.py, but fails elsewhere with `SystemError: Parent module '' not loaded, cannot perform relative import`.

Also, the method of fetching the version in setup.py has been simplified to avoid needing regex.

Also, another consideration that I can move to its own issue if you like:
- There appear to be no tests for the plugin presently, as I guess these don't fit so nicely into pytest, but something can probably be worked out. Perhaps by having some demo inputs and outputs to test just the plugin, rather than calling all of `protoc`, although both would be nice eventually.