### PR TITLE
Test for processor existence before attempting to close

### DIFF
--- a/grpclib/protocol.py
+++ b/grpclib/protocol.py
@@ -656,4 +656,10 @@ class H2Protocol(Protocol):
         self.connection.resume_writing()
 
     def connection_lost(self, exc: Optional[BaseException]) -> None:
-        self.processor.close(reason='Connection lost')
+        # In the case of an exception during connection setup, such as SSLError
+        # when invalid data is received, the connection_made method will never
+        # be called, but connection_lost is called with the exception.
+        # Therefore, the processor attribute may not have been setup and should
+        # be checked
+        if hasattr(self, 'processor'):
+            self.processor.close(reason='Connection lost')


### PR DESCRIPTION
See https://github.com/vmagamedov/grpclib/issues/91 for context

If there is an exception raised during connection setup (such as SSLError on invalid data/negotiation failure), `connection_made` will not be called but `connection_lost` will be called with the exception. This means that any properties setup during `connection_made` will not be set, resulting in the `AttributeError` during these failed connections.

With this fix, you will still see the `ssl.SSLError` printed from elsewhere, but the subsequent `AttributeError` is now prevented by checking for the existence of `processor` before trying to close it.