### PR TITLE
Allow stripping "+proto" from content-type header

### DIFF
--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -180,8 +180,14 @@ class Stream(StreamIterator[_RecvType], Generic[_SendType, _RecvType]):
             if self._deadline is not None:
                 timeout = self._deadline.time_remaining()
                 headers.append(('grpc-timeout', encode_timeout(timeout)))
-            content_type = (GRPC_CONTENT_TYPE
-                            + '+' + self._codec.__content_subtype__)
+            if (
+                    isinstance(self._codec, ProtoCodec)
+                    and not self._codec._send_content_subtype
+            ):
+                content_type = GRPC_CONTENT_TYPE
+            else:
+                content_type = (GRPC_CONTENT_TYPE
+                                + '+' + self._codec.__content_subtype__)
             headers.extend((
                 ('te', 'trailers'),
                 ('content-type', content_type),

--- a/grpclib/encoding/proto.py
+++ b/grpclib/encoding/proto.py
@@ -40,7 +40,7 @@ class ProtoCodec(CodecBase):
         """Initialize ProtoCodec instance
 
         :param send_content_subtype: whether or not to add "+proto" to the
-            "application/grpc" content-type headers sent by the Client/Server.
+            "application/grpc" content-type headers sent by the Channel/Server.
             Though header with subtype is supposed to be valid according to
             protocol, some servers (e.g. Google) expect no subtype.
         """

--- a/grpclib/encoding/proto.py
+++ b/grpclib/encoding/proto.py
@@ -36,6 +36,16 @@ def _googleapis_available() -> bool:
 class ProtoCodec(CodecBase):
     __content_subtype__ = 'proto'
 
+    def __init__(self, send_content_subtype: Optional[bool] = True) -> None:
+        """Initialize ProtoCodec instance
+
+        :param send_content_subtype: whether or not to add "+proto" to the
+            "application/grpc" content-type headers sent by the Client/Server.
+            Though header with subtype is supposed to be valid according to
+            protocol, some servers (e.g. Google) expect no subtype.
+        """
+        self._send_content_subtype = send_content_subtype
+
     def encode(
         self,
         message: 'IProtoMessage',

--- a/grpclib/server.py
+++ b/grpclib/server.py
@@ -100,7 +100,13 @@ class Stream(StreamIterator[_RecvType], Generic[_RecvType, _SendType]):
 
     @property
     def _content_type(self) -> str:
-        return GRPC_CONTENT_TYPE + '+' + self._codec.__content_subtype__
+        if (
+                isinstance(self._codec, ProtoCodec)
+                and not self._codec._send_content_subtype
+        ):
+            return GRPC_CONTENT_TYPE
+        else:
+            return GRPC_CONTENT_TYPE + '+' + self._codec.__content_subtype__
 
     async def recv_message(self) -> Optional[_RecvType]:
         """Coroutine to receive incoming message from the client.


### PR DESCRIPTION
Adds optional argument to ProtoCodec constructor to control whether "+proto" is added to "application/grpc" content-type headers sent by the Channel/Server. As discovered in #84, Google's servers do not accept a content-type header with "+proto". I tried to use the [Google Assistant gRPC API](https://developers.google.com/assistant/sdk/overview) with the same error. This should enable the use of Google APIs with this library.

```py
from grpclib.encoding.proto import ProtoCodec

c = Channel(API, '443', ssl=True, codec=ProtoCodec(send_content_subtype=False))
```