### PR TITLE
Trap the SSL npn protocols attribute error on Python 3.10

### DIFF
--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -756,6 +756,9 @@ class Channel:
             ctx.set_npn_protocols(['h2'])
         except NotImplementedError:
             pass
+        except AttributeError:
+            # Python 3.10 throws an attribute error now
+            pass
 
         return ctx
 

--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -1,3 +1,4 @@
+import ssl
 import sys
 import enum
 import http
@@ -752,13 +753,11 @@ class Channel:
         ctx.options |= (_ssl.OP_NO_TLSv1 | _ssl.OP_NO_TLSv1_1)
         ctx.set_ciphers('ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20')
         ctx.set_alpn_protocols(['h2'])
-        try:
-            ctx.set_npn_protocols(['h2'])
-        except NotImplementedError:
-            pass
-        except AttributeError:
-            # Python 3.10 throws an attribute error now
-            pass
+        if ssl.HAS_NPN:
+            try:
+                ctx.set_npn_protocols(['h2'])
+            except NotImplementedError:
+                pass
 
         return ctx
 

--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -1,4 +1,3 @@
-import ssl
 import sys
 import enum
 import http
@@ -754,10 +753,7 @@ class Channel:
         ctx.set_ciphers('ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20')
         ctx.set_alpn_protocols(['h2'])
         if ssl.HAS_NPN:
-            try:
-                ctx.set_npn_protocols(['h2'])
-            except NotImplementedError:
-                pass
+            ctx.set_npn_protocols(['h2'])
 
         return ctx
 

--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -752,7 +752,7 @@ class Channel:
         ctx.options |= (_ssl.OP_NO_TLSv1 | _ssl.OP_NO_TLSv1_1)
         ctx.set_ciphers('ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20')
         ctx.set_alpn_protocols(['h2'])
-        if ssl.HAS_NPN:
+        if _ssl.HAS_NPN:
             ctx.set_npn_protocols(['h2'])
 
         return ctx


### PR DESCRIPTION
closes #150 
@vmagamedov this fix allows `grpclib` to run on Python 3.10, by trapping the additional attribute error due to `npn` protocol being removed. Getting this integrated into the next RC would be ideal.