### PR TITLE
Fix double-close crash after abort, Python 3.11

### DIFF
--- a/grpclib/protocol.py
+++ b/grpclib/protocol.py
@@ -231,7 +231,8 @@ class Connection:
 
     def close(self) -> None:
         if hasattr(self, '_transport'):
-            self._transport.close()
+            if not self._transport.is_closing():
+                self._transport.close()
             # remove cyclic references to improve memory usage
             del self._transport
             if hasattr(self._connection, '_frame_dispatch_table'):


### PR DESCRIPTION
This addresses a crash I’ve been encountering with ssl on python 3.11 when the connection aborts unexpectedly.