### PR TITLE
Added wheel package upon release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ proto: clean
 release: proto
 	./scripts/release_check.sh
 	rm -rf grpclib.egg-info
-	python setup.py sdist
+	python setup.py sdist bdist_wheel
 
 reqs:
 	pip-compile -U setup.py -o setup.txt


### PR DESCRIPTION
For cross-compilation projects, as we are building ourselves, it is easier to have the wheel package also distributed upon release.

This small, but effective, change solves that :)