### PR TITLE
support ServerReflection with a custom DescriptorPool

### DIFF
--- a/grpclib/reflection/_deprecated.py
+++ b/grpclib/reflection/_deprecated.py
@@ -14,7 +14,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-from typing import Collection
+from typing import Any, Collection
 
 from google.protobuf.descriptor import FileDescriptor
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
@@ -35,10 +35,14 @@ class ServerReflection(ServerReflectionBase):
     """
     Implements server reflection protocol.
     """
-    def __init__(self, *, _service_names: Collection[str]):
+    def __init__(
+        self, *,
+        _service_names: Collection[str],
+        _pool: Any | None = None  # type: ignore
+    ):
         self._service_names = _service_names
         # FIXME: DescriptorPool has incomplete typings
-        self._pool = Default()  # type: ignore
+        self._pool = _pool or Default()  # type: ignore
 
     def _not_found_response(self) -> ServerReflectionResponse:
         return ServerReflectionResponse(

--- a/grpclib/reflection/_deprecated.py
+++ b/grpclib/reflection/_deprecated.py
@@ -14,7 +14,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-from typing import Any, Collection
+from typing import Any, Collection, Union
 
 from google.protobuf.descriptor import FileDescriptor
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
@@ -38,7 +38,7 @@ class ServerReflection(ServerReflectionBase):
     def __init__(
         self, *,
         _service_names: Collection[str],
-        _pool: Any | None = None  # type: ignore
+        _pool: Union[Any, None] = None
     ):
         self._service_names = _service_names
         # FIXME: DescriptorPool has incomplete typings

--- a/grpclib/reflection/_deprecated.py
+++ b/grpclib/reflection/_deprecated.py
@@ -38,7 +38,7 @@ class ServerReflection(ServerReflectionBase):
     def __init__(
         self, *,
         _service_names: Collection[str],
-        _pool: Union[Any, None] = None
+        _pool: Optional[Any] = None
     ):
         self._service_names = _service_names
         # FIXME: DescriptorPool has incomplete typings

--- a/grpclib/reflection/_deprecated.py
+++ b/grpclib/reflection/_deprecated.py
@@ -14,7 +14,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-from typing import Any, Collection, Union
+from typing import Any, Collection, Optional
 
 from google.protobuf.descriptor import FileDescriptor
 from google.protobuf.descriptor_pb2 import FileDescriptorProto

--- a/grpclib/reflection/service.py
+++ b/grpclib/reflection/service.py
@@ -14,7 +14,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-from typing import TYPE_CHECKING, Any, Collection, List
+from typing import TYPE_CHECKING, Any, Collection, List, Union
 
 from google.protobuf.descriptor import FileDescriptor
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
@@ -44,7 +44,7 @@ class ServerReflection(ServerReflectionBase):
     def __init__(
         self, *,
         _service_names: Collection[str],
-        _pool: Any | None = None  # type: ignore
+        _pool: Union[Any, None] = None
     ):
         self._service_names = _service_names
         # FIXME: DescriptorPool has incomplete typings
@@ -167,7 +167,7 @@ class ServerReflection(ServerReflectionBase):
     @classmethod
     def extend(
         cls, services: 'Collection[IServable]',
-        pool: Any | None = None   # type: ignore
+        pool: Union[Any, None] = None
     ) -> 'List[IServable]':
         """
         Extends services list with reflection service:

--- a/grpclib/reflection/service.py
+++ b/grpclib/reflection/service.py
@@ -14,7 +14,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-from typing import TYPE_CHECKING, Any, Collection, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Collection, List, Optional
 
 from google.protobuf.descriptor import FileDescriptor
 from google.protobuf.descriptor_pb2 import FileDescriptorProto

--- a/grpclib/reflection/service.py
+++ b/grpclib/reflection/service.py
@@ -14,7 +14,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-from typing import TYPE_CHECKING, Any, Collection, List, Union
+from typing import TYPE_CHECKING, Any, Collection, List, Optional, Union
 
 from google.protobuf.descriptor import FileDescriptor
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
@@ -44,7 +44,7 @@ class ServerReflection(ServerReflectionBase):
     def __init__(
         self, *,
         _service_names: Collection[str],
-        _pool: Union[Any, None] = None
+        _pool: Optional[Any] = None
     ):
         self._service_names = _service_names
         # FIXME: DescriptorPool has incomplete typings
@@ -167,7 +167,8 @@ class ServerReflection(ServerReflectionBase):
     @classmethod
     def extend(
         cls, services: 'Collection[IServable]',
-        pool: Union[Any, None] = None
+        *,
+        pool: Optional[Any] = None
     ) -> 'List[IServable]':
         """
         Extends services list with reflection service:


### PR DESCRIPTION
This is nice for libraries like betterproto2 to use for not interfering with the default pool while adding their own common types like Struct and having reflection still work!