### PR TITLE
Fix tests with pytest-asyncio >= 1.0.0

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
+import asyncio
+
 import pytest
 
 from grpclib.config import Configuration
 
 
 @pytest.fixture(name='loop')
-def loop_fixture(event_loop):
+async def loop_fixture():
     """ Shortcut """
-    return event_loop
+    return asyncio.get_running_loop()
 
 
 @pytest.fixture(name='config')


### PR DESCRIPTION
Update tests not to use the deprecated `event_loop` fixture that's been removed in pytest-asyncio >= 1.0.0.  Instead, use `asyncio.get_running_loop()` as the recommended replacement.  Make the fixture `async` as well to make things work correctly.

This change is compatible both with `pytest-asyncio >= 1.0.0` and `== 0.23.6`.