### PR TITLE
replace async-timeout with asyncio.timeout

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
         key: pip-${{ hashFiles('requirements/check.txt') }}
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.11"
     - run: pip3 install -r requirements/check.txt
     - run: pip3 install -e .
     - run: make proto
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Pure-Python gRPC implementation for asyncio
 
 |project|_ |documentation|_ |version|_ |tag|_ |downloads|_ |license|_
 
-This project is based on `hyper-h2`_ and **requires Python >= 3.8**.
+This project is based on `hyper-h2`_ and **requires Python >= 3.11**.
 
 .. contents::
   :local:

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,5 +2,4 @@
 pytest
 pytest-cov
 pytest-asyncio
-async_timeout
 faker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --annotation-style=line requirements/test.in
 #
-async-timeout==4.0.3      # via -r requirements/test.in
 certifi==2024.2.2         # via -r requirements/runtime.in
 coverage[toml]==7.4.4     # via pytest-cov
 exceptiongroup==1.2.0     # via pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,18 +15,16 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3 :: Only
     Topic :: Internet :: WWW/HTTP :: HTTP Servers
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.11
 install_requires=
     h2<5,>=3.1.0
     multidict

--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,5 @@ import setuptools
 
 setuptools.setup(
     name="grpclib",
-    python_requires='>=3.8',
+    python_requires='>=3.11',
 )

--- a/tests/test_client_stream.py
+++ b/tests/test_client_stream.py
@@ -3,7 +3,6 @@ import asyncio
 from unittest.mock import Mock
 
 import pytest
-import async_timeout
 import pytest_asyncio
 
 from faker import Faker
@@ -204,12 +203,12 @@ async def test_deadline_during_send_request():
     cs = ClientStream(timeout=0.01, connect_time=1,
                       send_type=DummyRequest, recv_type=DummyReply)
     with pytest.raises(ErrorDetected):
-        async with async_timeout.timeout(5) as safety_timeout:
+        async with asyncio.timeout(5) as safety_timeout:
             async with cs.client_stream as stream:
                 try:
                     await stream.send_request()
                 except asyncio.TimeoutError:
-                    if safety_timeout.expired:
+                    if safety_timeout.expired():
                         raise
                     else:
                         raise ErrorDetected()
@@ -220,7 +219,7 @@ async def test_deadline_during_send_message():
     cs = ClientStream(timeout=0.01,
                       send_type=DummyRequest, recv_type=DummyReply)
     with pytest.raises(ErrorDetected):
-        async with async_timeout.timeout(5) as safety_timeout:
+        async with asyncio.timeout(5) as safety_timeout:
             async with cs.client_stream as stream:
                 await stream.send_request()
 
@@ -229,7 +228,7 @@ async def test_deadline_during_send_message():
                     await stream.send_message(DummyRequest(value='ping'),
                                               end=True)
                 except asyncio.TimeoutError:
-                    if safety_timeout.expired:
+                    if safety_timeout.expired():
                         raise
                     else:
                         raise ErrorDetected()
@@ -240,7 +239,7 @@ async def test_deadline_during_recv_initial_metadata():
     cs = ClientStream(timeout=0.01,
                       send_type=DummyRequest, recv_type=DummyReply)
     with pytest.raises(ErrorDetected):
-        async with async_timeout.timeout(5) as safety_timeout:
+        async with asyncio.timeout(5) as safety_timeout:
             async with cs.client_stream as stream:
                 await stream.send_message(DummyRequest(value='ping'),
                                           end=True)
@@ -248,7 +247,7 @@ async def test_deadline_during_recv_initial_metadata():
                 try:
                     await stream.recv_initial_metadata()
                 except asyncio.TimeoutError:
-                    if safety_timeout.expired:
+                    if safety_timeout.expired():
                         raise
                     else:
                         raise ErrorDetected()
@@ -259,7 +258,7 @@ async def test_deadline_during_recv_message():
     cs = ClientStream(timeout=0.01,
                       send_type=DummyRequest, recv_type=DummyReply)
     with pytest.raises(ErrorDetected):
-        async with async_timeout.timeout(5) as safety_timeout:
+        async with asyncio.timeout(5) as safety_timeout:
             async with cs.client_stream as stream:
                 await stream.send_message(DummyRequest(value='ping'), end=True)
 
@@ -276,7 +275,7 @@ async def test_deadline_during_recv_message():
                 try:
                     await stream.recv_message()
                 except asyncio.TimeoutError:
-                    if safety_timeout.expired:
+                    if safety_timeout.expired():
                         raise
                     else:
                         raise ErrorDetected()
@@ -287,7 +286,7 @@ async def test_deadline_during_recv_trailing_metadata():
     cs = ClientStream(timeout=0.01,
                       send_type=DummyRequest, recv_type=DummyReply)
     with pytest.raises(ErrorDetected):
-        async with async_timeout.timeout(5) as safety_timeout:
+        async with asyncio.timeout(5) as safety_timeout:
             async with cs.client_stream as stream:
                 await stream.send_message(DummyRequest(value='ping'), end=True)
 
@@ -312,7 +311,7 @@ async def test_deadline_during_recv_trailing_metadata():
                 try:
                     await stream.recv_trailing_metadata()
                 except asyncio.TimeoutError:
-                    if safety_timeout.expired:
+                    if safety_timeout.expired():
                         raise
                     else:
                         raise ErrorDetected()
@@ -323,7 +322,7 @@ async def test_deadline_during_cancel():
     cs = ClientStream(timeout=0.01,
                       send_type=DummyRequest, recv_type=DummyReply)
     with pytest.raises(ErrorDetected):
-        async with async_timeout.timeout(5) as safety_timeout:
+        async with asyncio.timeout(5) as safety_timeout:
             async with cs.client_stream as stream:
                 await stream.send_request()
 
@@ -331,7 +330,7 @@ async def test_deadline_during_cancel():
                 try:
                     await stream.cancel()
                 except asyncio.TimeoutError:
-                    if safety_timeout.expired:
+                    if safety_timeout.expired():
                         raise
                     else:
                         raise ErrorDetected()

--- a/tests/test_health_service.py
+++ b/tests/test_health_service.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-import async_timeout
 
 from grpclib.const import Status
 from grpclib.testing import ChannelFor
@@ -110,7 +109,7 @@ async def test_watch_unknown_service():
                 status=HealthCheckResponse.SERVICE_UNKNOWN,
             )
             try:
-                async with async_timeout.timeout(0.01):
+                async with asyncio.timeout(0.01):
                     assert not await stream.recv_message()
             except asyncio.TimeoutError:
                 pass
@@ -131,7 +130,7 @@ async def test_watch_zero_checks():
                 status=HealthCheckResponse.SERVING,
             )
             try:
-                async with async_timeout.timeout(0.01):
+                async with asyncio.timeout(0.01):
                     assert not await stream.recv_message()
             except asyncio.TimeoutError:
                 pass
@@ -158,7 +157,7 @@ async def test_watch_service_check():
 
             # check that there are no unnecessary messages
             try:
-                async with async_timeout.timeout(0.01):
+                async with asyncio.timeout(0.01):
                     assert not await stream.recv_message()
             except asyncio.TimeoutError:
                 pass
@@ -217,7 +216,7 @@ async def test_watch_service_status():
             # changed
             s1.set(True)
             try:
-                async with async_timeout.timeout(0.01):
+                async with asyncio.timeout(0.01):
                     assert not await stream.recv_message()
             except asyncio.TimeoutError:
                 pass


### PR DESCRIPTION
Starting with Python 3.11, the functionality is available in the standard library.
Upstream says

> Therefore this library is considered deprecated and no longer actively supported.