### PR TITLE
Enhance Channel to accept a socket object

### DIFF
--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -723,7 +723,9 @@ class Channel:
 
     async def _create_connection(self) -> H2Protocol:
         server_hostname = (
-            self._config.ssl_target_name_override if self._ssl is not None else None
+            self._config.ssl_target_name_override
+            if self._ssl is not None
+            else None
         )
         if self._path is not None:
             _, protocol = await self._loop.create_unix_connection(

--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -5,6 +5,7 @@ import time
 import asyncio
 import warnings
 import ipaddress
+import socket
 
 from types import TracebackType
 from typing import Generic, Optional, Union, Type, List, Sequence, Any, cast
@@ -625,6 +626,7 @@ class Channel:
         ssl: Union[
             None, bool, "_ssl.SSLContext", "_ssl.DefaultVerifyPaths"
         ] = None,
+        socket: Optional[socket.socket] = None,
         config: Optional[Configuration] = None,
     ):
         """Initialize connection to the server
@@ -648,8 +650,14 @@ class Channel:
         :param ssl: ``True`` or :py:class:`~python:ssl.SSLContext` object or
             ``ssl.DefaultVerifyPaths`` object; if ``True``, default SSL context
             is used.
+
+        :param socket: socket object to use for the connection. If specified,
+            host, port and path should be omitted (must be None).
         """
-        if path is not None and (host is not None or port is not None):
+        if socket is not None and (host is not None or port is not None or path is not None):
+            raise ValueError("The 'socket' parameter can not be used with the "
+                             "'host', 'port' or 'path' parameters.")
+        elif path is not None and (host is not None or port is not None):
             raise ValueError("The 'path' parameter can not be used with the "
                              "'host' or 'port' parameters.")
         else:
@@ -681,6 +689,7 @@ class Channel:
         self._port = port
         self._loop = loop or asyncio.get_event_loop()
         self._path = path
+        self._socket = socket
         self._codec = codec
         self._status_details_codec = status_details_codec
         self._ssl = ssl or None
@@ -711,15 +720,21 @@ class Channel:
         return H2Protocol(Handler(), self._config, self._h2_config)
 
     async def _create_connection(self) -> H2Protocol:
+        server_hostname = self._config.ssl_target_name_override if self._ssl is not None else None
         if self._path is not None:
             _, protocol = await self._loop.create_unix_connection(
                 self._protocol_factory,
                 self._path,
                 ssl=self._ssl,
-                server_hostname=(
-                    self._config.ssl_target_name_override
-                    if self._ssl is not None else None
-                ),
+                server_hostname=server_hostname,
+            )
+        elif self._socket is not None:
+            _, protocol = await self._loop.create_connection(
+                self._protocol_factory,
+                
+                ssl=self._ssl,
+                server_hostname=server_hostname,
+                sock=self._socket,
             )
         else:
             _, protocol = await self._loop.create_connection(
@@ -727,10 +742,7 @@ class Channel:
                 self._host,
                 self._port,
                 ssl=self._ssl,
-                server_hostname=(
-                    self._config.ssl_target_name_override
-                    if self._ssl is not None else None
-                ),
+                server_hostname=server_hostname,
             )
         return protocol
 

--- a/grpclib/client.py
+++ b/grpclib/client.py
@@ -654,7 +654,9 @@ class Channel:
         :param socket: socket object to use for the connection. If specified,
             host, port and path should be omitted (must be None).
         """
-        if socket is not None and (host is not None or port is not None or path is not None):
+        if socket is not None and (
+            host is not None or port is not None or path is not None
+        ):
             raise ValueError("The 'socket' parameter can not be used with the "
                              "'host', 'port' or 'path' parameters.")
         elif path is not None and (host is not None or port is not None):
@@ -720,7 +722,9 @@ class Channel:
         return H2Protocol(Handler(), self._config, self._h2_config)
 
     async def _create_connection(self) -> H2Protocol:
-        server_hostname = self._config.ssl_target_name_override if self._ssl is not None else None
+        server_hostname = (
+            self._config.ssl_target_name_override if self._ssl is not None else None
+        )
         if self._path is not None:
             _, protocol = await self._loop.create_unix_connection(
                 self._protocol_factory,
@@ -731,7 +735,7 @@ class Channel:
         elif self._socket is not None:
             _, protocol = await self._loop.create_connection(
                 self._protocol_factory,
-                
+
                 ssl=self._ssl,
                 server_hostname=server_hostname,
                 sock=self._socket,

--- a/tests/test_client_channel.py
+++ b/tests/test_client_channel.py
@@ -2,6 +2,7 @@ import ssl
 import asyncio
 import tempfile
 import contextlib
+import socket
 from unittest.mock import patch, ANY
 
 import pytest
@@ -107,3 +108,39 @@ async def test_no_ssl_support():
         with pytest.raises(RuntimeError) as err:
             Channel(ssl=True)
         err.match("SSL is not supported")
+
+
+@pytest.mark.asyncio
+async def test_socket_parameter():
+    from unittest.mock import Mock
+
+    # Create a mock socket that tracks method calls
+    mock_sock = Mock(spec=socket.socket)
+    mock_sock.getpeername = Mock(return_value=("127.0.0.1", 12345))
+
+    # Mock the transport and protocol creation
+    mock_transport = Mock()
+    mock_protocol = Mock()
+
+    async def tracked_create_connection(_protocol_factory, **kwargs):
+        # Verify socket is passed and host/port are not passed
+        assert kwargs.get("sock") is mock_sock
+        assert "host" not in kwargs
+        assert "port" not in kwargs
+        return mock_transport, mock_protocol
+
+    with patch.object(
+        asyncio.get_event_loop(),
+        "create_connection",
+        side_effect=tracked_create_connection,
+    ):
+        channel = Channel(socket=mock_sock)
+        await channel.__connect__()
+        channel.close()
+
+
+def test_socket_conflicts():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        with pytest.raises(ValueError) as err:
+            Channel(host="localhost", socket=sock)
+        err.match("The 'socket' parameter can not be used")


### PR DESCRIPTION
Adding a `socket` kwarg to the `Channel` class, which is mutually exclusive with `path`, `host` and `user`.

Example:
```python
# External code
proxysocket = get_proxied_socket(proxyconfig)

# grpclib Channel
channel = grpclib.Channel(sock=mysocket)
```

To work around the limitation of no Proxy support (#191), we would like to initialize the socket outside of grpclib so we can connect to the proxy first and then handover to grpclib.

Purposedly this is a small change, but it will allow us to implement proxy support in downstream libraries.

We would be happy to submit a pull-request for proper proxy support in grpclib later.